### PR TITLE
Change DTOs classes to Record

### DIFF
--- a/src/main/java/com/flashcardsspring/Flashcards/domain/Card.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/domain/Card.java
@@ -14,8 +14,8 @@ import lombok.*;
 @EqualsAndHashCode(of = "card_id")
 public class Card {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long card_id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String card_id;
     private String question;
     private String answer;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/flashcardsspring/Flashcards/domain/Deck.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/domain/Deck.java
@@ -16,8 +16,8 @@ import java.util.List;
 @EqualsAndHashCode(of = "deck_id")
 public class Deck {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long deck_id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String deck_id;
     private String name;
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/flashcardsspring/Flashcards/domain/User.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/domain/User.java
@@ -16,8 +16,8 @@ import java.util.List;
 
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
     private String name;
     private String email;
     private String password;

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/CardRequestDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/CardRequestDTO.java
@@ -8,19 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class CardRequestDTO {
-    @NotNull
-    @NotBlank
-    private String question;
-    @NotNull
-    @NotBlank
-    private String answer;
-    @NotNull
-    private Feedback feedback;
-    @NotNull
-    private DeckIdRequestDTO deckIdRequestDTO;
+public record CardRequestDTO(@NotNull @NotBlank String question, @NotNull @NotBlank String answer, @NotNull Feedback feedback, @NotNull DeckIdRequestDTO deckIdRequestDTO) {
+
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/CardRequestUpdateDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/CardRequestUpdateDTO.java
@@ -5,11 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class CardRequestUpdateDTO {
-    private String question;
-    private String answer;
+public record CardRequestUpdateDTO(String question, String answer) {
+
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/DeckIdRequestDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/DeckIdRequestDTO.java
@@ -5,10 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class DeckIdRequestDTO {
-    private Long deck_id;
+public record DeckIdRequestDTO(Long deck_id) {
+
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/DeckRequestDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/DeckRequestDTO.java
@@ -7,15 +7,5 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class DeckRequestDTO {
-    @NotNull
-    @NotBlank
-    private String name;
-    @NotNull
-    private UserIdRequestDTO userIdRequestDTO;
+public record DeckRequestDTO(@NotNull @NotBlank String name, @NotNull UserIdRequestDTO userIdRequestDTO) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/DeckRequestUpdateDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/DeckRequestUpdateDTO.java
@@ -7,12 +7,5 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class DeckRequestUpdateDTO {
-    @NotNull
-    @NotBlank
-    private String name;
+public record DeckRequestUpdateDTO(@NotNull @NotBlank String name) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserIdRequestDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserIdRequestDTO.java
@@ -5,10 +5,5 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class UserIdRequestDTO {
-    private String user_id;
+public record UserIdRequestDTO(String user_id) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserIdRequestDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserIdRequestDTO.java
@@ -10,5 +10,5 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserIdRequestDTO {
-    private Long user_id;
+    private String user_id;
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserRequestDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserRequestDTO.java
@@ -7,18 +7,5 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class UserRequestDTO {
-    @NotNull
-    @NotBlank
-    private String name;
-    @NotNull
-    @NotBlank
-    private String email;
-    @NotNull
-    @NotBlank
-    private String password;
+public record UserRequestDTO(@NotNull @NotBlank String name, @NotNull @NotBlank String email, @NotNull @NotBlank String password) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserRequestUpdateDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/request/UserRequestUpdateDTO.java
@@ -7,12 +7,5 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class UserRequestUpdateDTO {
-    @NotNull
-    @NotBlank
-    private String name;
+public record UserRequestUpdateDTO(@NotNull @NotBlank String name) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/response/CardResponseDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/response/CardResponseDTO.java
@@ -8,14 +8,5 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class CardResponseDTO {
-    private String id;
-    private String question;
-    private String answer;
-    private Feedback feedback;
+public record CardResponseDTO(String id, String question, String answer, Feedback feedback) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/response/DeckResponseDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/response/DeckResponseDTO.java
@@ -16,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DeckResponseDTO {
-    private Long deck_id;
+    private String deck_id;
     private String name;
     private List<Card> cards = new ArrayList<>();
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/response/DeckResponseDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/response/DeckResponseDTO.java
@@ -10,13 +10,5 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.List;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class DeckResponseDTO {
-    private String deck_id;
-    private String name;
-    private List<Card> cards = new ArrayList<>();
+public record DeckResponseDTO(String deck_id, String name, List<Card> cards) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/response/UserResponseDTO.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserResponseDTO {
-    private Long id;
+    private String id;
     private String name;
     private String email;
     private List<DeckResponseDTO> decks  = new ArrayList<>();

--- a/src/main/java/com/flashcardsspring/Flashcards/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/dto/response/UserResponseDTO.java
@@ -9,14 +9,5 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.List;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class UserResponseDTO {
-    private String id;
-    private String name;
-    private String email;
-    private List<DeckResponseDTO> decks  = new ArrayList<>();
+public record UserResponseDTO(String id, String name, String email, List<DeckResponseDTO> decks) {
 }

--- a/src/main/java/com/flashcardsspring/Flashcards/resources/CardResource.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/resources/CardResource.java
@@ -39,10 +39,9 @@ public class CardResource {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createCard(@RequestBody @Valid CardRequestDTO card, UriComponentsBuilder builder) {
-        var response = cardService.createCard(card);
-        var uri = builder.path("/cards/{id}").buildAndExpand(response.getId()).toUri();
-        return ResponseEntity.created(uri).build();
+    public ResponseEntity<CardResponseDTO> createCard(@RequestBody @Valid CardRequestDTO card, UriComponentsBuilder builder) {
+        CardResponseDTO response = cardService.createCard(card);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping(value = "/{id}")

--- a/src/main/java/com/flashcardsspring/Flashcards/resources/DeckResource.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/resources/DeckResource.java
@@ -34,10 +34,9 @@ public class DeckResource {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createDeck(@RequestBody @Valid DeckRequestDTO deck, UriComponentsBuilder builder) {
+    public ResponseEntity<DeckResponseDTO> createDeck(@RequestBody @Valid DeckRequestDTO deck, UriComponentsBuilder builder) {
         var response = deckService.createDeck(deck);
-        var uri = builder.path("/decks/{id}").buildAndExpand(response.getDeck_id()).toUri();
-        return ResponseEntity.created(uri).build();
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping(value = "/{id}")

--- a/src/main/java/com/flashcardsspring/Flashcards/resources/UserResource.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/resources/UserResource.java
@@ -36,10 +36,9 @@ public class UserResource {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createUser(@RequestBody @Valid UserRequestDTO user, UriComponentsBuilder builder) {
-        var response = userService.createUser(user);
-        var uri = builder.path("users/{id}").buildAndExpand(response.getId()).toUri();
-        return ResponseEntity.created(uri).build();
+    public ResponseEntity<UserResponseDTO> createUser(@RequestBody @Valid UserRequestDTO user, UriComponentsBuilder builder) {
+        UserResponseDTO response = userService.createUser(user);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping(value = "/{id}")

--- a/src/main/java/com/flashcardsspring/Flashcards/services/CardService.java
+++ b/src/main/java/com/flashcardsspring/Flashcards/services/CardService.java
@@ -38,8 +38,9 @@ public class CardService {
         return modelMapper.map(card, CardResponseDTO.class);
     }
 
+    // TODO: modify the createCard method params to accept a deckId
     public CardResponseDTO createCard(CardRequestDTO card) {
-        Optional<Deck> deck = deckRepository.findById(card.getDeckIdRequestDTO().getDeck_id());
+        Optional<Deck> deck = deckRepository.findById(card.deckIdRequestDTO().deck_id());
         if (deck.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Deck not found");
         }


### PR DESCRIPTION
Records in Java are a special kind of class introduced in Java 14 as a preview feature and finalized in Java 16. They are intended to be a concise way to declare classes that are supposed to be "dumb" data holders.

Here are some reasons why you might want to use records instead of traditional classes:  

1 - Less Boilerplate: Records automatically generate a lot of boilerplate code for you. When you declare a record, the compiler automatically generates a constructor, equals(), hashCode(), toString(), and getter methods for you. This can significantly reduce the amount of code you have to write and maintain.  

2 - Immutability: Records are immutable by default. This means that once a record is created, its state cannot be changed. This can be a useful property in many situations, especially in multi-threaded environments where mutable state can lead to bugs.  

3 - Express Intent: By using a record, you are expressing a clear intent that this type is a simple data carrier with no additional functionality. This can make your code easier to understand.